### PR TITLE
 Rely on Go Modules to ensure package dependencies and replicable builds. Testing go version 1.11 to 1.15

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,18 @@
+on: [push, pull_request]
+name: Test
+jobs:
+  test:
+    strategy:
+      matrix:
+        go-version: [1.11.x, 1.12.x, 1.13.x, 1.14.x, 1.15.x]
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{ matrix.go-version }}
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Test
+      run: make test

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,28 @@
+# Go parameters
+GOCMD=GO111MODULE=on go
+GOBUILD=$(GOCMD) build
+GOINSTALL=$(GOCMD) install
+GOCLEAN=$(GOCMD) clean
+GOTEST=$(GOCMD) test
+GOGET=$(GOCMD) get
+GOMOD=$(GOCMD) mod
+GOFMT=$(GOCMD) fmt
+
+.PHONY: all test coverage
+all: test coverage build
+
+build:
+	$(GOBUILD) .
+
+get:
+	$(GOGET) -t -v ./...
+
+fmt:
+	$(GOFMT) ./...
+
+test: get fmt
+	$(GOTEST) -count=1 ./...
+
+coverage: get test
+	$(GOTEST) -race -coverprofile=coverage.txt -covermode=atomic .
+

--- a/README.md
+++ b/README.md
@@ -18,8 +18,7 @@ The easiest way to get and install the Subscriber Go program is to use
 # Fetch this repo
 go get github.com/filipecosta90/pubsub-sub-bench
 cd $GOPATH/src/github.com/filipecosta90/pubsub-sub-bench
-go get ./...
-go build .
+make
 ```
 
 ## Usage of pubsub-sub-bench

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module github.com/filipecosta90/pubsub-sub-bench
+
+go 1.13
+
+require (
+	github.com/HdrHistogram/hdrhistogram-go v0.0.0-20200919145931-8dac23c8dac1 // indirect
+	github.com/mediocregopher/radix/v3 v3.5.2
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,9 @@
+github.com/HdrHistogram/hdrhistogram-go v0.0.0-20200919145931-8dac23c8dac1 h1:nEjGZtKHMK92888VT6XkzKwyiW14v5FFRGeWq2uV7N0=
+github.com/HdrHistogram/hdrhistogram-go v0.0.0-20200919145931-8dac23c8dac1/go.mod h1:nxrse8/Tzg2tg3DZcZjm6qEclQKK70g0KxO61gFFZD4=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/mediocregopher/radix/v3 v3.5.2 h1:A9u3G7n4+fWmDZ2ZDHtlK+cZl4q55T+7RjKjR0/MAdk=
+github.com/mediocregopher/radix/v3 v3.5.2/go.mod h1:8FL3F6UQRXHXIBSPUs5h0RybMF8i4n7wVopoX3x7Bv8=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898 h1:/atklqdjdhuosWIl6AIbOeHJjicWYPqR9bpxqxYG2pA=
+golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/subscriber.go
+++ b/subscriber.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"github.com/mediocregopher/radix"
+	"github.com/mediocregopher/radix/v3"
 	"io/ioutil"
 	"log"
 	"os"


### PR DESCRIPTION
This is a small PR to push forward this project towards latest go version standards. 

- Rely on Go Modules to ensure package dependencies and replicable builds. We need this in order to: Automatically detect import statements and then update dependencies graph, lock, download, and install appropriate versions of packages.
[Quoting golang official docs](https://github.com/golang/go/wiki/Modules#go-modules):
     > In Go 1.14, module support is considered ready for production use, and all users are encouraged to migrate to modules from other dependency management systems.
- Rely on github actions to proceed with the tests. 
- Testing for go version 1.11 to 1.15, for both ubuntu, windows, and macos environments. 
